### PR TITLE
Added mutable_content option

### DIFF
--- a/message.go
+++ b/message.go
@@ -46,6 +46,7 @@ type Message struct {
 	CollapseKey              string                 `json:"collapse_key,omitempty"`
 	Priority                 string                 `json:"priority,omitempty"`
 	ContentAvailable         bool                   `json:"content_available,omitempty"`
+	MutableContent           bool                   `json:"mutable_content,omitempty"`
 	DelayWhileIdle           bool                   `json:"delay_while_idle,omitempty"`
 	TimeToLive               *uint                  `json:"time_to_live,omitempty"`
 	DeliveryReceiptRequested bool                   `json:"delivery_receipt_requested,omitempty"`


### PR DESCRIPTION
[The issue](https://github.com/firebase/quickstart-ios/issues/70) at Firebase project was resolved, so it would be nice to have an option for `mutable-content` for iOS devices which use Firebase as a bridge for APNS.
A link to official documentation is: https://firebase.google.com/docs/cloud-messaging/http-server-ref#mutable_content