### PR TITLE
Fixing a space typo in json schema

### DIFF
--- a/message.go
+++ b/message.go
@@ -24,7 +24,7 @@ var (
 type Notification struct {
 	Title        string `json:"title,omitempty"`
 	Body         string `json:"body,omitempty"`
-	ChannelId    string `json:"android_channel_id, omitempty"`
+	ChannelID    string `json:"android_channel_id,omitempty"`
 	Icon         string `json:"icon,omitempty"`
 	Sound        string `json:"sound,omitempty"`
 	Badge        string `json:"badge,omitempty"`


### PR DESCRIPTION
To send a [data message](https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages) from Firebase to Android, `notification` key should be left empty. The typo prevents it, as it sends a request which looks like this:

```json
{
  "registration_ids": ["token1", "token2"],
  "content_available": true,
  "mutable_content": true,
  "notification": {
    "android_channel_id": ""
  },
  "data": {
    "hello": "world"
  }
}
```

`ChannelId` is renamed to `ChannelID`, because of `golint` warning: 
> struct field ChannelId should be ChannelID (golint)

A **gorush** project probably needs a vendor update after that as well.