### PR TITLE
Add option WithTimeout

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -28,7 +28,7 @@ func TestSend(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, err := NewClient("test", WithEndpoint(server.URL))
+		client, err := NewClient("test", WithEndpoint(server.URL), WithTimeout(10*time.Second))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/option.go
+++ b/option.go
@@ -3,6 +3,7 @@ package fcm
 import (
 	"errors"
 	"net/http"
+	"time"
 )
 
 // Option configurates Client with defined option.
@@ -23,6 +24,17 @@ func WithEndpoint(endpoint string) Option {
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(c *Client) error {
 		c.client = httpClient
+		return nil
+	}
+}
+
+// WithTimeout returns Option to configure HTTP Client timeout.
+func WithTimeout(d time.Duration) Option {
+	return func(c *Client) error {
+		if d.Nanoseconds() <= 0 {
+			return errors.New("invalid timeout duration")
+		}
+		c.timeout = d
 		return nil
 	}
 }


### PR DESCRIPTION
Add `timeout` support for HTTP calls. Hope it'll be helpful when using `goroutine` to avoid memory/process leaking. DefaultTimeout is `30 Seconds`.

Code:
```go
client, err := NewClient("test", WithEndpoint(server.URL), WithTimeout(10*time.Second))
		if err != nil {
			t.Fatalf("unexpected error: %v", err)
		}
```