### PR TITLE
chore: Increase maximum condition operators to 5

### DIFF
--- a/message.go
+++ b/message.go
@@ -67,7 +67,7 @@ func (msg *Message) Validate() error {
 
 	// validate target identifier: `to` or `condition`, or `registration_ids`
 	opCnt := strings.Count(msg.Condition, "&&") + strings.Count(msg.Condition, "||")
-	if msg.To == "" && (msg.Condition == "" || opCnt > 2) && len(msg.RegistrationIDs) == 0 {
+	if msg.To == "" && (msg.Condition == "" || opCnt > 5) && len(msg.RegistrationIDs) == 0 {
 		return ErrInvalidTarget
 	}
 

--- a/message_test.go
+++ b/message_test.go
@@ -93,7 +93,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("invalid condition", func(t *testing.T) {
 		msg := &Message{
-			Condition: "'TopicA' in topics && ('TopicB' in topics || 'TopicC' in topics || 'TopicD' in topics )",
+			Condition: "'TopicA' in topics && ('TopicB' in topics || 'TopicC' in topics || 'TopicD' in topics || 'TopicE' in topics || 'TopicF' in topics)",
 			Data: map[string]interface{}{
 				"message": "This is a Firebase Cloud Messaging Topic Message!",
 			},

--- a/message_test.go
+++ b/message_test.go
@@ -93,7 +93,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("invalid condition", func(t *testing.T) {
 		msg := &Message{
-			Condition: "'TopicA' in topics && ('TopicB' in topics || 'TopicC' in topics || 'TopicD' in topics || 'TopicE' in topics || 'TopicF' in topics)",
+			Condition: "'TopicA' in topics && 'TopicB' in topics && 'TopicC' in topics && 'TopicD' in topics && 'TopicE' in topics && 'TopicF' in topics && 'TopicG' in topics && 'TopicH' in topics",
 			Data: map[string]interface{}{
 				"message": "This is a Firebase Cloud Messaging Topic Message!",
 			},


### PR DESCRIPTION
"You can include up to five topics in your conditional expression, and parentheses are supported. Supported operators: &&, ||, !. Note the usage for !:"

Reference: firebase.google.com/docs/cloud-messaging/send-message

fixed #23 