### PR TITLE
Return Error Response Code

### DIFF
--- a/response.go
+++ b/response.go
@@ -121,8 +121,9 @@ type Response struct {
 	FailedRegistrationIDs []string `json:"failed_registration_ids"`
 
 	// Topic HTTP response
-	MessageID int64 `json:"message_id"`
-	Error     error `json:"error"`
+	MessageID         int64 `json:"message_id"`
+	Error             error `json:"error"`
+	ErrorResponseCode string
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -154,6 +155,7 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	r.Success = response.Success
 	r.FailedRegistrationIDs = response.FailedRegistrationIDs
 	r.MessageID = response.MessageID
+	r.ErrorResponseCode = response.Error
 	if response.Error != "" {
 		if val, ok := errMap[response.Error]; ok {
 			r.Error = val
@@ -167,9 +169,10 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 
 // Result represents the status of a processed message.
 type Result struct {
-	MessageID      string `json:"message_id"`
-	RegistrationID string `json:"registration_id"`
-	Error          error  `json:"error"`
+	MessageID         string `json:"message_id"`
+	RegistrationID    string `json:"registration_id"`
+	Error             error  `json:"error"`
+	ErrorResponseCode string
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -186,6 +189,7 @@ func (r *Result) UnmarshalJSON(data []byte) error {
 
 	r.MessageID = result.MessageID
 	r.RegistrationID = result.RegistrationID
+	r.ErrorResponseCode = result.Error
 	if result.Error != "" {
 		if val, ok := errMap[result.Error]; ok {
 			r.Error = val

--- a/response_test.go
+++ b/response_test.go
@@ -31,9 +31,10 @@ func TestUnmarshal(t *testing.T) {
 			Failure:      1,
 			CanonicalIDs: 10,
 			Results: []Result{{
-				MessageID:      "q1w2e3r4",
-				RegistrationID: "t5y6u7i8o9",
-				Error:          ErrNotRegistered,
+				MessageID:         "q1w2e3r4",
+				RegistrationID:    "t5y6u7i8o9",
+				Error:             ErrNotRegistered,
+				ErrorResponseCode: "NotRegistered",
 			}},
 		}
 		if !reflect.DeepEqual(response, expected) {
@@ -85,8 +86,9 @@ func TestUnmarshal(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		expected := Response{
-			MessageID: int64(1023456),
-			Error:     errMap["TopicsMessageRateExceeded"],
+			MessageID:         int64(1023456),
+			Error:             errMap["TopicsMessageRateExceeded"],
+			ErrorResponseCode: "TopicsMessageRateExceeded",
 		}
 		if !reflect.DeepEqual(response, expected) {
 			t.Fatalf("expected: %v\ngot: %v", expected, response)


### PR DESCRIPTION
I want actual Error response code in gorush error logging.
gorush write log(or error response when sync mode),
 error message like `invalid registration token`, `unregistered device`.

I want to remove useless device token automatically by another batch program.

I don't want to implement this program depending on gorush internal log implementaion.

if gorush log(or return error response) actual error response code,
I can implement program dependeing on firebase official api reference :)
