### PR TITLE
Remove duplicate assignment

### DIFF
--- a/response.go
+++ b/response.go
@@ -152,7 +152,6 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	r.Failure = response.Failure
 	r.CanonicalIDs = response.CanonicalIDs
 	r.Results = response.Results
-	r.Success = response.Success
 	r.FailedRegistrationIDs = response.FailedRegistrationIDs
 	r.MessageID = response.MessageID
 	r.ErrorResponseCode = response.Error


### PR DESCRIPTION
Remove duplicate assignment for the success response in `json.Unmarshaler` interface