### PR TITLE
feat: enable HTTP request/response logging in debug mode

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,6 +36,7 @@ type Client struct {
 	options         []option.ClientOption
 	httpClient      *http.Client
 	credentialsJSON []byte // credentialsJSON is the JSON representation of the service account credentials.
+	debug           bool
 }
 
 // NewClient creates new Firebase Cloud Messaging Client based on API key and
@@ -54,6 +55,20 @@ func NewClient(ctx context.Context, opts ...Option) (*Client, error) {
 		conf = &firebase.Config{
 			ServiceAccountID: c.serviceAcount,
 			ProjectID:        c.projectID,
+		}
+	}
+
+	if c.debug {
+		if c.httpClient == nil {
+			c.httpClient = &http.Client{
+				Transport: debugTransport{
+					t: http.DefaultTransport,
+				},
+			}
+		} else {
+			c.httpClient.Transport = debugTransport{
+				t: c.httpClient.Transport,
+			}
 		}
 	}
 

--- a/debug.go
+++ b/debug.go
@@ -1,0 +1,32 @@
+package fcm
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+)
+
+type debugTransport struct {
+	t http.RoundTripper
+}
+
+func (d debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqDump, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("%s", reqDump)
+
+	resp, err := d.t.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	respDump, err := httputil.DumpResponse(resp, true)
+	if err != nil {
+		resp.Body.Close()
+		return nil, err
+	}
+	log.Printf("%s", respDump)
+	return resp, nil
+}

--- a/option.go
+++ b/option.go
@@ -94,3 +94,11 @@ func WithTokenSource(s oauth2.TokenSource) Option {
 		return nil
 	}
 }
+
+// WithDebug returns Option to configure debug mode.
+func WithDebug(debug bool) Option {
+	return func(c *Client) error {
+		c.debug = debug
+		return nil
+	}
+}


### PR DESCRIPTION
- Add `debug` field to `Client` struct
- Initialize `httpClient` with `debugTransport` if `debug` mode is enabled
- Create `debug.go` to define `debugTransport` for logging HTTP requests and responses
- Add `WithDebug` option to configure debug mode in `option.go`