### PR TITLE
feat: re-add WithCustomClientOption, useful for unit testing.

### DIFF
--- a/option.go
+++ b/option.go
@@ -102,3 +102,23 @@ func WithDebug(debug bool) Option {
 		return nil
 	}
 }
+
+// WithCustomClientOption is an option function that allows you to provide custom client options.
+// It appends the provided custom options to the client's options list.
+// The custom options are applied when sending requests to the FCM server.
+// If no custom options are provided, this function does nothing.
+//
+// Parameters:
+//   - opts: The custom client options to be appended to the client's options list.
+//
+// Returns:
+//   - An error if there was an issue appending the custom options to the client's options list, or nil otherwise.
+func WithCustomClientOption(opts ...option.ClientOption) Option {
+	return func(c *Client) error {
+		if len(opts) == 0 {
+			return nil
+		}
+		c.options = append(c.options, opts...)
+		return nil
+	}
+}


### PR DESCRIPTION
Hi, 

Could you re-add `WithCustomClientOption`? 

My existing unit tests make use of `WithEndpoint` with a `httptest.NewServer` URL. But it needs to be used in combination with [option.WithoutAuthentication()](https://github.com/life360/push360/blob/ef9baa170f92a7d539d488b32cbb0be10ec6ae4c/vendor/google.golang.org/api/option/option.go#L190-L197) so that the client can be initialized correctly (see example in README). 

Doing this, there's no need to have a local dummy Credentials file for unit testing.