### PR TITLE
refactor: simplify client wrappers and option helpers

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,7 +30,7 @@ var scopes = []string{
 // - https://www.googleapis.com/auth/firebase.messaging
 type Client struct {
 	client          *messaging.Client
-	serviceAcount   string
+	serviceAccount  string
 	projectID       string
 	options         []option.ClientOption
 	httpClient      *http.Client
@@ -50,25 +50,22 @@ func NewClient(ctx context.Context, opts ...Option) (*Client, error) {
 	}
 
 	var conf *firebase.Config
-	if c.serviceAcount != "" || c.projectID != "" {
+	if c.serviceAccount != "" || c.projectID != "" {
 		conf = &firebase.Config{
-			ServiceAccountID: c.serviceAcount,
+			ServiceAccountID: c.serviceAccount,
 			ProjectID:        c.projectID,
 		}
 	}
 
 	if c.debug {
 		if c.httpClient == nil {
-			c.httpClient = &http.Client{
-				Transport: debugTransport{
-					t: http.DefaultTransport,
-				},
-			}
-		} else {
-			c.httpClient.Transport = debugTransport{
-				t: c.httpClient.Transport,
-			}
+			c.httpClient = &http.Client{}
 		}
+		base := c.httpClient.Transport
+		if base == nil {
+			base = http.DefaultTransport
+		}
+		c.httpClient.Transport = debugTransport{t: base}
 	}
 
 	if c.httpClient != nil {
@@ -106,20 +103,14 @@ func NewClient(ctx context.Context, opts ...Option) (*Client, error) {
 	return c, nil
 }
 
-// SendWithContext sends a message to the FCM server without retrying in case of service
+// Send sends a message to the FCM server without retrying in case of service
 // unavailability. A non-nil error is returned if a non-recoverable error
 // occurs (i.e. if the response status is not "200 OK").
-// Behaves just like regular send, but uses external context.
 func (c *Client) Send(
 	ctx context.Context,
 	message ...*messaging.Message,
 ) (*messaging.BatchResponse, error) {
-	resp, err := c.client.SendEach(ctx, message)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return c.client.SendEach(ctx, message)
 }
 
 // SendDryRun sends the messages in the given array via Firebase Cloud Messaging in the
@@ -128,42 +119,27 @@ func (c *Client) SendDryRun(
 	ctx context.Context,
 	message ...*messaging.Message,
 ) (*messaging.BatchResponse, error) {
-	resp, err := c.client.SendEachDryRun(ctx, message)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return c.client.SendEachDryRun(ctx, message)
 }
 
-// SendEachForMulticast sends the given multicast message to all the FCM registration tokens specified.
+// SendMulticast sends the given multicast message to all the FCM registration tokens specified.
 func (c *Client) SendMulticast(
 	ctx context.Context,
 	message *messaging.MulticastMessage,
 ) (*messaging.BatchResponse, error) {
-	resp, err := c.client.SendEachForMulticast(ctx, message)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return c.client.SendEachForMulticast(ctx, message)
 }
 
-// SendEachForMulticastDryRun sends the given multicast message to all the specified FCM registration
+// SendMulticastDryRun sends the given multicast message to all the specified FCM registration
 // tokens in the dry run (validation only) mode.
 func (c *Client) SendMulticastDryRun(
 	ctx context.Context,
 	message *messaging.MulticastMessage,
 ) (*messaging.BatchResponse, error) {
-	resp, err := c.client.SendEachForMulticastDryRun(ctx, message)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return c.client.SendEachForMulticastDryRun(ctx, message)
 }
 
-// SubscribeToTopic subscribes a list of registration tokens to a topic.
+// SubscribeTopic subscribes a list of registration tokens to a topic.
 //
 // The tokens list must not be empty, and have at most 1000 tokens.
 func (c *Client) SubscribeTopic(
@@ -171,15 +147,10 @@ func (c *Client) SubscribeTopic(
 	tokens []string,
 	topic string,
 ) (*messaging.TopicManagementResponse, error) {
-	resp, err := c.client.SubscribeToTopic(ctx, tokens, topic)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return c.client.SubscribeToTopic(ctx, tokens, topic)
 }
 
-// UnsubscribeFromTopic unsubscribes a list of registration tokens from a topic.
+// UnsubscribeTopic unsubscribes a list of registration tokens from a topic.
 //
 // The tokens list must not be empty, and have at most 1000 tokens.
 func (c *Client) UnsubscribeTopic(
@@ -187,10 +158,5 @@ func (c *Client) UnsubscribeTopic(
 	tokens []string,
 	topic string,
 ) (*messaging.TopicManagementResponse, error) {
-	resp, err := c.client.UnsubscribeFromTopic(ctx, tokens, topic)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return c.client.UnsubscribeFromTopic(ctx, tokens, topic)
 }

--- a/doc.go
+++ b/doc.go
@@ -12,20 +12,17 @@
 //			log.Fatal(err)
 //		}
 //
-//	// Send to a single device
-//	token := "test"
-//	resp, err := client.Send(
-//
-//	ctx,
-//	&messaging.Message{
-//		Token: token,
-//		Data: map[string]string{
-//			"foo": "bar",
-//		},
-//	},
-//
-// )
-//
+//		// Send to a single device
+//		token := "test"
+//		resp, err := client.Send(
+//			ctx,
+//			&messaging.Message{
+//				Token: token,
+//				Data: map[string]string{
+//					"foo": "bar",
+//				},
+//			},
+//		)
 //		if err != nil {
 //			log.Fatal(err)
 //		}

--- a/option.go
+++ b/option.go
@@ -45,8 +45,7 @@ func WithCredentialsFile(filename string) Option {
 		if err != nil {
 			return fmt.Errorf("cannot read credentials file: %v", err)
 		}
-		c.credentialsJSON = data
-		c.options = append(c.options, option.WithAuthCredentialsJSON(option.ServiceAccount, data))
+		c.setCredentials(data)
 		return nil
 	}
 }
@@ -56,10 +55,16 @@ func WithCredentialsFile(filename string) Option {
 // credentials.
 func WithCredentialsJSON(data []byte) Option {
 	return func(c *Client) error {
-		c.credentialsJSON = data
-		c.options = append(c.options, option.WithAuthCredentialsJSON(option.ServiceAccount, data))
+		c.setCredentials(data)
 		return nil
 	}
+}
+
+// setCredentials stores the raw credentials JSON and registers it as a
+// Firebase client option.
+func (c *Client) setCredentials(data []byte) {
+	c.credentialsJSON = data
+	c.options = append(c.options, option.WithAuthCredentialsJSON(option.ServiceAccount, data))
 }
 
 // WithEndpoint returns Option to configure endpoint.
@@ -73,7 +78,7 @@ func WithEndpoint(endpoint string) Option {
 // WithServiceAccount returns Option to configure service account.
 func WithServiceAccount(serviceAccount string) Option {
 	return func(c *Client) error {
-		c.serviceAcount = serviceAccount
+		c.serviceAccount = serviceAccount
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary

Quality-only cleanup of the `fcm` package — no behavior changes. Builds clean, `go vet` and `gofmt` pass, and all tests are green.

- **Collapse pass-through wrappers** — `Send`, `SendDryRun`, `SendMulticast`, `SendMulticastDryRun`, `SubscribeTopic`, and `UnsubscribeTopic` each had a redundant `resp, err := …; if err != nil { return nil, err }; return resp, nil`. They now return the underlying call directly (~50 lines removed).
- **Fix godoc comments** — comments named non-existent or SDK-internal methods (`SendWithContext`, `SendEachForMulticast`, `UnsubscribeFromTopic`). They now lead with the actual method name per Go convention.
- **Extract `setCredentials` helper** — `WithCredentialsFile` and `WithCredentialsJSON` shared identical credential-registration logic; now centralized.
- **Rename misspelled field** — `serviceAcount` → `serviceAccount`.
- **Flatten debug transport setup** — replaced the nested nil/non-nil branch with a single ensure-client-then-wrap path that also defaults a nil transport to `http.DefaultTransport`.
- **Reformat package example** — fixed broken mid-example indentation in `doc.go`.

## Test plan

- `go build ./...`
- `go vet ./...`
- `gofmt -l .` (clean)
- `go test ./...` (pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)